### PR TITLE
Updated link for getting started

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -62,7 +62,7 @@ our opencollective.*
 [Discord]: https://discord.neoforged.net/
 
 [Documentation]: https://docs.neoforged.net/
-[Getting-Started]: https://docs.neoforged.net/en/latest/gettingstarted/
+[Getting-Started]: https://docs.neoforged.net/docs/gettingstarted/
 [ForgeDev]: https://docs.neoforged.net/en/latest/forgedev/
 [Pull-Requests]: https://docs.neoforged.net/en/latest/forgedev/#making-changes-and-pull-requests
 [CurseForge]: https://curseforge.com/placeholder


### PR DESCRIPTION
Old link was going to 404, so I replaced it with the correct link.